### PR TITLE
Removed command type checks, no longer needed because now in main regexp

### DIFF
--- a/lib/parser/index.js
+++ b/lib/parser/index.js
@@ -144,31 +144,23 @@ function parse(filepath, templates, opts) {
           var _ln = ln;
           var _idx = idx;
 
-          if(m[posMap.cmdType].match(/^[=!>?]/)) {
-            tasks.push(
-              parseRule(templates, filepath, m[posMap.cmd], m[posMap.cmdType], m[posMap.cmdArgs], indent, ln, opts)
-                .catch(function(err) {
-                  errStack.push({
-                    indent: indent,
-                    idx: _idx,
-                    err: err
-                  });
+          tasks.push(
+            parseRule(templates, filepath, m[posMap.cmd], m[posMap.cmdType], m[posMap.cmdArgs], indent, ln, opts)
+              .catch(function(err) {
+                errStack.push({
+                  indent: indent,
+                  idx: _idx,
+                  err: err
+                });
 
-                  return {
-                    ln: _ln,
-                    sql: _m[0],
-                    idx: _idx
-                  };
-                })
+                return {
+                  ln: _ln,
+                  sql: _m[0],
+                  idx: _idx
+                };
+              })
 
-            );
-          } else {
-            tasks.push({
-              sql: m[posMap.cmd],
-              ln: ln,
-              idx: idx
-            });
-          }
+          );
 
         } else if(m[posMap.nl]) {
           tasks.push({


### PR DESCRIPTION
This was noticed thanks to codeclimate (https://codeclimate.com/github/orangemug/sql-stamp/coverage/577c1340a38da2000104026e)

Test coverage has declined to 99.7% (-0.3).