### PR TITLE
add tests for regex parsing

### DIFF
--- a/lib/parser/index.js
+++ b/lib/parser/index.js
@@ -1,9 +1,10 @@
-var Bluebird  = require("bluebird");
-var util      = require("../util");
-var operators = require("../operators");
-var runner    = require("./runner");
-var stack     = require("./stack");
-var errors    = require("../errors");
+var Bluebird    = require("bluebird");
+var util        = require("../util");
+var operators   = require("../operators");
+var runner      = require("./runner");
+var stack       = require("./stack");
+var errors      = require("../errors");
+var parserRegex = require("./regex");
 
 var fs = Bluebird.promisifyAll(
   require("fs")
@@ -106,16 +107,10 @@ function parse(filepath, templates, opts) {
        *     )/gm
        *
        */
-      var re = /(?:(\{([#=?!>])([^}{]*)\})|([\n])|(.[^}{\n]*))/gm;
+      var re = parserRegex.re();
       var ln = 0;
 
-      var posMap = {
-        cmd: 1,
-        cmdType: 2,
-        cmdArgs: 3,
-        nl: 4,
-        sql: 5,
-      };
+      var posMap = parserRegex.posMap;
 
       var idx = -1;
       var m;

--- a/lib/parser/regex.js
+++ b/lib/parser/regex.js
@@ -1,0 +1,48 @@
+module.exports = {
+  re: function () {
+    /**
+     * Ok so this regexp is a little confusing, so lets break it down
+     *
+     * Firstly its aim is to walk over a string (using RegExp#exec). The RegExp will always match something and the grouping tells us what that something is
+     *
+     * It'll be either a
+     *
+     *  - COMMAND, with a nested:
+     *    - COMMAND_TYPE
+     *    - COMMAND_ARGS
+     *  - NEWLINE
+     *  - SQL
+     *
+     * Which is mapped in 'posMap' below
+     *
+     * These are commented in the broken apart regexp below
+     *
+     *     # group but ignore in output
+     *     /(?:
+     *       # Is the current part a known templating [COMMAND]
+     *       (
+     *         \{
+     *          # Capture the [COMMAND_TYPE]
+     *          ([#=?!>])
+     *          # Capture the [COMMAND_ARGS], up to the next '{' or '}'
+     *          ([^}{]*)
+     *         \}
+     *       )
+     *       # OR is it a [NEWLINE]
+     *       |([\n])
+     *       # ELSE its some [SQL] match upto the next '{' or '}' this is kind of a hack to allow braces that are not a part of the syntax
+     *       |(.[^}{\n]*)
+     *     # Global and multiline
+     *     )/gm
+     *
+     */
+    return /(?:(\{([#=?!>])([^}{]*)\})|([\n])|(.[^}{\n]*))/gm;
+  },
+  posMap: {
+    cmd: 1, // interpretted command such as {> ../file.sql}
+    cmdType: 2, // type of command such as #, =, ?, ! or >
+    cmdArgs: 3, // arguments passed to the command such as ../file.sql
+    nl: 4, // a new line
+    sql: 5, // any ordinary SQL
+  }
+};

--- a/test/index.js
+++ b/test/index.js
@@ -5,6 +5,7 @@ require("./operators/param-default");
 require("./operators/raw");
 require("./operators/require");
 require("./operators/no-operator");
+require("./parser/regex");
 
 // Full end-to-end test
 require("./functional");

--- a/test/parser/regex.js
+++ b/test/parser/regex.js
@@ -1,0 +1,56 @@
+var regex      = require("../../lib/parser/regex");
+var assert     = require("assert");
+
+describe("parser/regex", function () {
+
+  it("should parse {>foo}", function () {
+    var test1 = "{>foo}";
+    var results = regex.re().exec(test1);
+    assert.equal(results[1], test1);
+    assert.equal(results[2], ">");
+    assert.equal(results[3], "foo");
+  });
+
+  it("should parse {=foo}", function () {
+    var test2 = "{=foo}";
+    var results = regex.re().exec(test2);
+    assert.equal(results[1], test2);
+    assert.equal(results[2], "=");
+    assert.equal(results[3], "foo");
+  });
+
+  it("should parse {!foo}", function () {
+    var test4 = "{!foo}";
+    var results = regex.re().exec(test4);
+    assert.equal(results[1], test4);
+    assert.equal(results[2], "!");
+    assert.equal(results[3], "foo");
+  });
+
+  it("should parse {{=foo}}", function () {
+    var test3 = "{=foo}";
+    var results = regex.re().exec(test3);
+    assert.equal(results[1], test3);
+    assert.equal(results[2], "=");
+    assert.equal(results[3], "foo");
+  });
+
+  it("should handle SQL `WHERE fish = 'false'`", function () {
+    var test4 = "WHERE fish = 'false'";
+    var results = regex.re().exec(test4);
+    assert.equal(results[5], test4);
+  });
+
+  it("should handle SQL `WHERE fish = IN({'cod', 'hake'})`", function () {
+    var test5 = "WHERE fish = IN({'cod', 'hake'})";
+    var re = regex.re();
+
+    // Match in parts
+    var result1 = re.exec(test5);
+    assert.equal(result1[5], "WHERE fish = IN(");
+    var result2 = re.exec(test5);
+    assert.equal(result2[5], "{'cod', 'hake'");
+    var result3 = re.exec(test5);
+    assert.equal(result3[5], "})");
+  });
+});


### PR DESCRIPTION
Wanted to start deconstructing the active parts of the parsing in steps for the sql-stamp sync. The pulls the regex component out and adds tests for it.